### PR TITLE
#70 - Fix ForwardStreamController leak on VM 

### DIFF
--- a/lib/src/_impl/web/_channel_impl.dart
+++ b/lib/src/_impl/web/_channel_impl.dart
@@ -232,8 +232,8 @@ final class _WebChannel implements Channel {
   }
   
   @override
-  // TODO: implement activeConnectionsCount
-  int get activeConnectionsCount => throw UnimplementedError();
+  @visibleForTesting
+  int get activeConnectionsCount => _activeConnections.length;
 }
 
 extension on WorkerRequest {

--- a/lib/src/_impl/web/_channel_impl.dart
+++ b/lib/src/_impl/web/_channel_impl.dart
@@ -230,6 +230,10 @@ final class _WebChannel implements Channel {
     final post = inspectRequest ? _inspectAndPostRequest : _postRequest;
     return _getResponseStream(com, req, post, streaming: true);
   }
+  
+  @override
+  // TODO: implement activeConnectionsCount
+  int get activeConnectionsCount => throw UnimplementedError();
 }
 
 extension on WorkerRequest {

--- a/lib/src/_impl/xplat/_disconnected_channel.dart
+++ b/lib/src/_impl/xplat/_disconnected_channel.dart
@@ -58,4 +58,8 @@ final class DisconnectedChannel implements Channel {
 
   @override
   Channel share() => _disconnectedError();
+  
+  @visibleForTesting
+  @override
+  int get activeConnectionsCount => 0;
 }

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -78,6 +78,9 @@ abstract interface class Channel {
     ExceptionManager? exceptionManager,
   ]) =>
       impl.deserialize(channelInfo, logger, exceptionManager);
+
+  @visibleForTesting
+  int get activeConnectionsCount;
 }
 
 @internal

--- a/lib/src/worker/worker.dart
+++ b/lib/src/worker/worker.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cancelation_token/cancelation_token.dart';
 import 'package:logger/web.dart';
+import 'package:meta/meta.dart';
 import 'package:using/using.dart';
 
 import '../_impl/xplat/_forward_completer.dart';
@@ -76,6 +77,12 @@ abstract class Worker
 
   /// Shared [Channel] that can be used to communicate with the worker.
   Channel? getSharedChannel() => _channel?.share();
+
+  @visibleForTesting
+  int get activeConnectionsCount =>
+      // rationale: valid, at this itself is @visibleForTesting.
+      // ignore: invalid_use_of_visible_for_testing_member
+      _channel?.activeConnectionsCount ?? 0;
 
   Channel? _channel;
   Future<Channel>? _openChannel;

--- a/test/12_issues_test.dart
+++ b/test/12_issues_test.dart
@@ -92,16 +92,13 @@ void execute(TestContext? tc) {
           '- #70 - ForwardStreamController released after stream is closed',
           () {
         tc.test('- sendRequest should clean up controllers', () async {
-          // This test only applies to VM platform where we can access internals
-          if (!tc.runnerPlatform.isVm) return;
 
           await IssuesWorker(tc).useAsync((w) async {
             await w.start();
 
             final initialCount = w.activeConnectionsCount;
             expect(initialCount, greaterThanOrEqualTo(0),
-                reason:
-                    'activeConnectionsCount should be accessible on VM platform');
+                reason: 'activeConnectionsCount should be accessible');
 
             // Make multiple sendRequest calls
             for (int i = 0; i < 10; i++) {
@@ -120,8 +117,6 @@ void execute(TestContext? tc) {
         });
 
         tc.test('- sendStreamingRequest should clean up controllers', () async {
-          // This test only applies to VM platform where we can access internals
-          if (!tc.runnerPlatform.isVm) return;
 
           await IssuesWorker(tc).useAsync((w) async {
             await w.start();
@@ -146,8 +141,6 @@ void execute(TestContext? tc) {
 
         tc.test('- Early canceled streams should clean up controllers',
             () async {
-          // This test only applies to VM platform where we can access internals
-          if (!tc.runnerPlatform.isVm) return;
 
           await IssuesWorker(tc).useAsync((w) async {
             await w.start();

--- a/test/12_issues_test.dart
+++ b/test/12_issues_test.dart
@@ -87,6 +87,87 @@ void execute(TestContext? tc) {
           });
         });
       });
+
+      tc.group(
+          '- #70 - ForwardStreamController released after stream is closed',
+          () {
+        tc.test('- sendRequest should clean up controllers', () async {
+          // This test only applies to VM platform where we can access internals
+          if (!tc.runnerPlatform.isVm) return;
+
+          await IssuesWorker(tc).useAsync((w) async {
+            await w.start();
+
+            final initialCount = w.activeConnectionsCount;
+            expect(initialCount, greaterThanOrEqualTo(0),
+                reason:
+                    'activeConnectionsCount should be accessible on VM platform');
+
+            // Make multiple sendRequest calls
+            for (int i = 0; i < 10; i++) {
+              await w.getVersion();
+            }
+
+            // Give time for any async cleanup
+            await Future.delayed(Duration(milliseconds: 100));
+
+            // Verify controllers were cleaned up
+            final finalCount = w.activeConnectionsCount;
+            expect(finalCount, equals(initialCount),
+                reason:
+                    'Memory leak detected: ${finalCount - initialCount} ForwardStreamControllers retained after 10 requests');
+          });
+        });
+
+        tc.test('- sendStreamingRequest should clean up controllers', () async {
+          // This test only applies to VM platform where we can access internals
+          if (!tc.runnerPlatform.isVm) return;
+
+          await IssuesWorker(tc).useAsync((w) async {
+            await w.start();
+
+            final initialCount = w.activeConnectionsCount;
+
+            // Make a streaming request and fully consume it
+            final values = <dynamic>[];
+            await for (final value in w.issue_8([0, 1])) {
+              values.add(value);
+            }
+
+            // Give time for cleanup
+            await Future.delayed(Duration(milliseconds: 100));
+
+            final finalCount = w.activeConnectionsCount;
+            expect(finalCount, equals(initialCount),
+                reason:
+                    'Memory leak detected: ${finalCount - initialCount} ForwardStreamControllers retained after streaming request');
+          });
+        });
+
+        tc.test('- Early canceled streams should clean up controllers',
+            () async {
+          // This test only applies to VM platform where we can access internals
+          if (!tc.runnerPlatform.isVm) return;
+
+          await IssuesWorker(tc).useAsync((w) async {
+            await w.start();
+
+            final initialCount = w.activeConnectionsCount;
+
+            // Create a streaming request but cancel it early by only taking first value
+            final firstValue = await w.issue_8([0, 1, 2, 3, 4]).first;
+            expect(firstValue, {'id': 1, 'num': 0});
+
+            // Give time for cleanup after early cancellation
+            await Future.delayed(Duration(milliseconds: 200));
+
+            final finalCount = w.activeConnectionsCount;
+            expect(finalCount, equals(initialCount),
+                reason:
+                    'Memory leak detected: ${finalCount - initialCount} ForwardStreamControllers retained after early stream cancellation');
+          });
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
Rough patch that seems to resolve memory leak on native for #70 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new property to display the current number of active connections in various classes and interfaces.
* **Bug Fixes**
  * Improved cleanup of resources to prevent memory leaks after streams are closed.
* **Tests**
  * Introduced new tests to verify that active connections are properly released after use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->